### PR TITLE
feat(shell): add interactive shell mode

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,6 +26,7 @@ Available commands:
   /config            - Display current configuration
   /rag on|off        - Toggle RAG feature
   /rag path <path>   - Set the RAG documents path
+  /shell             - Enter shell mode
   /quit              - Exit the application
 ```
 
@@ -45,6 +46,29 @@ Provider: https://api.openai.com
 RAG Enabled: true
 RAG Path: /home/user/documents
 ```
+
+### `/shell`
+Enters shell mode, allowing you to execute shell commands directly.
+
+**Usage:**
+```
+/shell
+```
+
+**Example:**
+```
+> /shell
+Entered shell mode. Type 'exit' to return.
+shell> ls -l
+-rw-r--r-- 1 user user 1024 Oct 27 10:00 file.txt
+shell> exit
+Exited shell mode.
+```
+
+**Notes:**
+- In shell mode, all input is treated as a shell command.
+- To exit shell mode, type `exit` and press Enter.
+- Slash commands are not available while in shell mode.
 
 ### `/quit`
 Exits the Agent-Go application gracefully, saving any unsaved changes and cleaning up resources.

--- a/src/completion.go
+++ b/src/completion.go
@@ -91,6 +91,7 @@ func buildCompleter(config *Config) readline.AutoCompleter {
 			readline.PcItem("off"),
 			readline.PcItem("path"), // Only suggests the "path" keyword.
 		),
+		readline.PcItem("/shell"),
 		readline.PcItem("/quit"),
 	)
 

--- a/src/main.go
+++ b/src/main.go
@@ -16,6 +16,7 @@ import (
 
 var config *Config
 var agent *Agent
+var shellMode = false
 
 func main() {
 	// Display ASCII logo
@@ -94,6 +95,12 @@ func runCLI() {
 	fmt.Println("Agent-Go is ready. Type your requests, or /help for a list of commands.")
 
 	for {
+		if shellMode {
+			rl.SetPrompt("shell> ")
+		} else {
+			rl.SetPrompt("> ")
+		}
+
 		userInput, err := rl.Readline()
 		if err == readline.ErrInterrupt {
 			continue
@@ -102,6 +109,24 @@ func runCLI() {
 		}
 
 		userInput = strings.TrimSpace(userInput)
+
+		if shellMode {
+			if userInput == "exit" {
+				shellMode = false
+				fmt.Println("Exited shell mode.")
+				continue
+			}
+			if userInput == "" {
+				continue
+			}
+			output, err := executeCommand(userInput)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+			}
+			fmt.Println(output)
+			continue
+		}
+
 		if userInput == "" {
 			continue
 		}
@@ -205,7 +230,11 @@ func handleSlashCommand(command string) {
 		fmt.Println("  /config            - Display current configuration")
 		fmt.Println("  /rag on|off        - Toggle RAG feature")
 		fmt.Println("  /rag path <path>   - Set the RAG documents path")
+		fmt.Println("  /shell             - Enter shell mode for direct command execution")
 		fmt.Println("  /quit              - Exit the application")
+	case "/shell":
+		shellMode = true
+		fmt.Println("Entered shell mode. Type 'exit' to return.")
 	case "/quit":
 		fmt.Println("Bye!")
 		os.Exit(0)


### PR DESCRIPTION
This introduces a new /shell command that allows users to enter an
interactive shell mode.

In this mode, all user input is treated as a direct shell command and
executed immediately, with the output printed to the console. The command
prompt changes to "shell> " to provide clear visual feedback.

To exit shell mode and return to the standard agent interaction, the
user can type 'exit'. The /shell command has also been added to the
autocompletion list and the command documentation.