### PR TITLE
feat(commands): add /subagents on|off command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,7 @@ Available commands:
   /compress          - Compress context and start new chat thread
   /contextlength <value> - Set the model context length
   /stream on|off     - Toggle streaming mode
+  /subagents on|off  - Toggle sub-agent spawning
   /quit              - Exit the application
 ```
 
@@ -457,6 +458,32 @@ Streaming enabled.
 - Reduces perceived latency for long responses
 - Automatically disabled when shell mode is entered
 - Can be toggled at any time during a session
+
+### `/subagents on|off`
+
+Toggles the ability for the main agent to spawn sub-agents for complex tasks.
+
+**Usage:**
+
+```
+/subagents on|off
+```
+
+**Examples:**
+
+```
+> /subagents off
+Sub-agent spawning disabled.
+
+> /subagents on
+Sub-agent spawning enabled.
+```
+
+**Notes:**
+
+- When disabled, the `spawn_agent` tool is not available to the AI, preventing it from delegating tasks.
+- This can be useful for forcing the primary agent to handle all tasks directly.
+- The setting is saved to your configuration file.
 
 ### Token Usage Tracking
 

--- a/src/completion.go
+++ b/src/completion.go
@@ -96,6 +96,10 @@ func buildCompleter(config *Config) readline.AutoCompleter {
 			readline.PcItem("on"),
 			readline.PcItem("off"),
 		),
+		readline.PcItem("/subagents",
+			readline.PcItem("on"),
+			readline.PcItem("off"),
+		),
 		readline.PcItem("/shell"),
 		readline.PcItem("/quit"),
 	)

--- a/src/config.go
+++ b/src/config.go
@@ -20,6 +20,7 @@ func loadConfig() *Config {
 		AutoCompressThreshold: 20,
 		ModelContextLength:    131072,
 		Stream:                false,
+		SubagentsEnabled:      true,
 	}
 
 	home, err := os.UserHomeDir()
@@ -68,6 +69,9 @@ func loadConfig() *Config {
 	}
 	if stream := os.Getenv("STREAM_ENABLED"); stream == "1" || stream == "true" {
 		config.Stream = true
+	}
+	if subagents := os.Getenv("SUBAGENTS_ENABLED"); subagents == "0" || subagents == "false" {
+		config.SubagentsEnabled = false
 	}
 
 	return config

--- a/src/main.go
+++ b/src/main.go
@@ -173,9 +173,9 @@ func runCLI() {
 
 			// Use streaming or regular API based on config
 			if config.Stream {
-				resp, err = sendAPIRequestStreaming(agent, config, true)
+				resp, err = sendAPIRequestStreaming(agent, config, config.SubagentsEnabled)
 			} else {
-				resp, err = sendAPIRequest(agent, config, true)
+				resp, err = sendAPIRequest(agent, config, config.SubagentsEnabled)
 			}
 
 			if err != nil {
@@ -284,6 +284,7 @@ func handleSlashCommand(command string) {
 		fmt.Println("  /compress          - Compress context and start new chat thread")
 		fmt.Println("  /contextlength <value> - Set the model context length (e.g., 131072)")
 		fmt.Println("  /stream on|off     - Toggle streaming mode")
+		fmt.Println("  /subagents on|off  - Toggle sub-agent spawning")
 		fmt.Println("  /quit              - Exit the application")
 	case "/contextlength":
 		if len(parts) > 1 {
@@ -329,6 +330,7 @@ func handleSlashCommand(command string) {
 		fmt.Printf("Auto Compress Threshold: %d\n", config.AutoCompressThreshold)
 		fmt.Printf("Model Context Length: %d\n", config.ModelContextLength)
 		fmt.Printf("Stream Enabled: %t\n", config.Stream)
+		fmt.Printf("Subagents Enabled: %t\n", config.SubagentsEnabled)
 	case "/rag":
 		if len(parts) > 1 {
 			switch parts[1] {
@@ -379,6 +381,27 @@ func handleSlashCommand(command string) {
 		}
 	default:
 		fmt.Printf("Unknown command: %s\n", baseCommand)
+	case "/subagents":
+		if len(parts) > 1 {
+			switch parts[1] {
+			case "on":
+				config.SubagentsEnabled = true
+				saveConfig(config)
+				fmt.Println("Sub-agent spawning enabled.")
+			case "off":
+				config.SubagentsEnabled = false
+				saveConfig(config)
+				fmt.Println("Sub-agent spawning disabled.")
+			default:
+				fmt.Println("Usage: /subagents [on|off]")
+			}
+		} else {
+			if config.SubagentsEnabled {
+				fmt.Println("Sub-agent spawning is currently enabled.")
+			} else {
+				fmt.Println("Sub-agent spawning is currently disabled.")
+			}
+		}
 	}
 }
 
@@ -487,9 +510,9 @@ func runTask(task string) {
 
 		// Use streaming or regular API based on config
 		if config.Stream {
-			resp, err = sendAPIRequestStreaming(agent, config, true)
+			resp, err = sendAPIRequestStreaming(agent, config, config.SubagentsEnabled)
 		} else {
-			resp, err = sendAPIRequest(agent, config, true)
+			resp, err = sendAPIRequest(agent, config, config.SubagentsEnabled)
 		}
 
 		if err != nil {

--- a/src/types.go
+++ b/src/types.go
@@ -20,6 +20,7 @@ type Config struct {
 	AutoCompressThreshold int     `json:"auto_compress_threshold"`
 	ModelContextLength    int     `json:"model_context_length"`
 	Stream                bool    `json:"stream"`
+	SubagentsEnabled      bool    `json:"subagents_enabled"`
 }
 
 type Agent struct {


### PR DESCRIPTION
This commit introduces a new slash command, `/subagents`, allowing users to toggle the sub-agent spawning functionality at runtime.

A `SubagentsEnabled` field is added to the configuration, defaulting to true, which can be controlled via the new command or the `SUBAGENTS_ENABLED` environment variable. API requests now respect this setting, controlling whether the `spawn_agent` tool is available to the model.

- Implements the `/subagents [on|off]` command logic.
- Adds `SubagentsEnabled` to the config struct and loading process.
- Updates API calls to conditionally include the `spawn_agent` tool.
- Adds autocompletion for the new command and its options.
- Updates `/help`, `/config` output, and `docs/commands.md` with the new feature.