### PR TITLE
feat(core): implement plan mode with execution safety

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -20,7 +20,7 @@ func sendAPIRequest(agent *Agent, config *Config, includeSpawn bool) (*APIRespon
 		MaxTokens:   config.MaxTokens,
 		Stream:      config.Stream,
 		ToolChoice:  "auto",
-		Tools:       getAvailableTools(includeSpawn),
+		Tools:       getAvailableTools(includeSpawn, config.OperationMode),
 	}
 
 	jsonData, err := json.Marshal(requestBody)
@@ -153,7 +153,7 @@ func sendAPIRequestStreaming(agent *Agent, config *Config, includeSpawn bool) (*
 		MaxTokens:   config.MaxTokens,
 		Stream:      true,
 		ToolChoice:  "auto",
-		Tools:       getAvailableTools(includeSpawn),
+		Tools:       getAvailableTools(includeSpawn, config.OperationMode),
 	}
 
 	jsonData, err := json.Marshal(requestBody)

--- a/src/config.go
+++ b/src/config.go
@@ -22,6 +22,7 @@ func loadConfig() *Config {
 		Stream:                false,
 		SubagentsEnabled:      true,
 		ExecutionMode:         Ask,
+		OperationMode:         Build,
 	}
 	config.MCPs = make(map[string]MCPServer)
 
@@ -93,6 +94,13 @@ func loadConfig() *Config {
 			config.ExecutionMode = YOLO
 		} else {
 			config.ExecutionMode = Ask
+		}
+	}
+	if operationMode := os.Getenv("OPERATION_MODE"); operationMode != "" {
+		if operationMode == "plan" {
+			config.OperationMode = Plan
+		} else {
+			config.OperationMode = Build
 		}
 	}
 	return config

--- a/src/executor.go
+++ b/src/executor.go
@@ -28,6 +28,11 @@ var (
 
 // confirmAndExecute checks the execution mode and prompts for confirmation if necessary.
 func confirmAndExecute(config *Config, command string, background bool) (string, error) {
+	// Check operation mode first
+	if config.OperationMode == Plan {
+		return "", fmt.Errorf("command execution is blocked in Plan mode. Switch to Build mode to execute commands")
+	}
+
 	// We need to lock here because multiple sub-agents might try to execute commands
 	// or ask for confirmation simultaneously, which would mess up the console I/O.
 	executionMutex.Lock()

--- a/src/tools.go
+++ b/src/tools.go
@@ -17,10 +17,16 @@ type UpdateTodoArgs struct {
 	Status string `json:"status"`
 }
 
+type SuggestPlanArgs struct {
+	Plan string `json:"plan"`
+}
+
 // getAvailableTools returns the list of tools available to the agent
-func getAvailableTools(includeSpawn bool) []Tool {
-	tools := []Tool{
-		{
+func getAvailableTools(includeSpawn bool, operationMode OperationMode) []Tool {
+	tools := []Tool{}
+
+	if operationMode == Build {
+		tools = append(tools, Tool{
 			Type: "function",
 			Function: FunctionDefinition{
 				Name:        "execute_command",
@@ -34,135 +40,163 @@ func getAvailableTools(includeSpawn bool) []Tool {
 					"required": []string{"command"},
 				},
 			},
-		},
-		{
-			Type: "function",
-			Function: FunctionDefinition{
-				Name:        "create_todo",
-				Description: "Create a new todo item.",
-				Parameters: map[string]interface{}{
-					"type":       "object",
-					"properties": map[string]interface{}{"task": map[string]string{"type": "string"}},
-					"required":   []string{"task"},
-				},
-			},
-		},
-		{
-			Type: "function",
-			Function: FunctionDefinition{
-				Name:        "update_todo",
-				Description: "Update a todo item's status.",
-				Parameters: map[string]interface{}{
-					"type": "object",
-					"properties": map[string]interface{}{
-						"id":     map[string]interface{}{"type": "integer"},
-						"status": map[string]interface{}{"type": "string", "enum": []string{"pending", "in-progress", "completed"}},
-					},
-					"required": []string{"id", "status"},
-				},
-			},
-		},
-		{
-			Type: "function",
-			Function: FunctionDefinition{
-				Name:        "get_todo_list",
-				Description: "Get the current list of todo items.",
-				Parameters:  map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
-			},
-		},
-		{
-			Type: "function",
-			Function: FunctionDefinition{
-				Name:        "create_note",
-				Description: "Create a note. Notes persist across sessions and are injected into the system prompt.",
-				Parameters: map[string]interface{}{
-					"type": "object",
-					"properties": map[string]interface{}{
-						"name":    map[string]string{"type": "string", "description": "Unique name for the note"},
-						"content": map[string]string{"type": "string", "description": "Content of the note"},
-					},
-					"required": []string{"name", "content"},
-				},
-			},
-		},
-		{
-			Type: "function",
-			Function: FunctionDefinition{
-				Name:        "update_note",
-				Description: "Update an existing note's content.",
-				Parameters: map[string]interface{}{
-					"type": "object",
-					"properties": map[string]interface{}{
-						"name":    map[string]string{"type": "string", "description": "Name of the note to update"},
-						"content": map[string]string{"type": "string", "description": "New content for the note"},
-					},
-					"required": []string{"name", "content"},
-				},
-			},
-		},
-		{
-			Type: "function",
-			Function: FunctionDefinition{
-				Name:        "delete_note",
-				Description: "Delete a note.",
-				Parameters: map[string]interface{}{
-					"type": "object",
-					"properties": map[string]interface{}{
-						"name": map[string]string{"type": "string", "description": "Name of the note to delete"},
-					},
-					"required": []string{"name"},
-				},
-			},
-		},
-		{
-			Type: "function",
-			Function: FunctionDefinition{
-				Name:        "name_session",
-				Description: "Give the current session a name. This helps organize and restore sessions later.",
-				Parameters: map[string]interface{}{
-					"type": "object",
-					"properties": map[string]interface{}{
-						"name": map[string]string{"type": "string", "description": "New name for the session (use dashes for spaces, e.g., 'implement-auth-feature')"},
-					},
-					"required": []string{"name"},
-				},
-			},
-		},
+		})
 	}
 
-	// Add background command tools
 	tools = append(tools, Tool{
 		Type: "function",
 		Function: FunctionDefinition{
-			Name:        "kill_background_command",
-			Description: "Kill a running background command by PID.",
+			Name:        "create_todo",
+			Description: "Create a new todo item.",
 			Parameters: map[string]interface{}{
 				"type":       "object",
-				"properties": map[string]interface{}{"pid": map[string]interface{}{"type": "integer"}},
-				"required":   []string{"pid"},
+				"properties": map[string]interface{}{"task": map[string]string{"type": "string"}},
+				"required":   []string{"task"},
 			},
 		},
 	})
+
 	tools = append(tools, Tool{
 		Type: "function",
 		Function: FunctionDefinition{
-			Name:        "get_background_logs",
-			Description: "Get the logs (stdout/stderr) of a background command by PID.",
+			Name:        "update_todo",
+			Description: "Update a todo item's status.",
 			Parameters: map[string]interface{}{
-				"type":       "object",
-				"properties": map[string]interface{}{"pid": map[string]interface{}{"type": "integer"}},
-				"required":   []string{"pid"},
+				"type": "object",
+				"properties": map[string]interface{}{
+					"id":     map[string]interface{}{"type": "integer"},
+					"status": map[string]interface{}{"type": "string", "enum": []string{"pending", "in-progress", "completed"}},
+				},
+				"required": []string{"id", "status"},
 			},
 		},
 	})
+
 	tools = append(tools, Tool{
 		Type: "function",
 		Function: FunctionDefinition{
-			Name:        "list_background_commands",
-			Description: "List all running background commands.",
+			Name:        "get_todo_list",
+			Description: "Get the current list of todo items.",
 			Parameters:  map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
 		},
 	})
+
+	tools = append(tools, Tool{
+		Type: "function",
+		Function: FunctionDefinition{
+			Name:        "create_note",
+			Description: "Create a note. Notes persist across sessions and are injected into the system prompt.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name":    map[string]string{"type": "string", "description": "Unique name for the note"},
+					"content": map[string]string{"type": "string", "description": "Content of the note"},
+				},
+				"required": []string{"name", "content"},
+			},
+		},
+	})
+
+	tools = append(tools, Tool{
+		Type: "function",
+		Function: FunctionDefinition{
+			Name:        "update_note",
+			Description: "Update an existing note's content.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name":    map[string]string{"type": "string", "description": "Name of the note to update"},
+					"content": map[string]string{"type": "string", "description": "New content for the note"},
+				},
+				"required": []string{"name", "content"},
+			},
+		},
+	})
+
+	tools = append(tools, Tool{
+		Type: "function",
+		Function: FunctionDefinition{
+			Name:        "delete_note",
+			Description: "Delete a note.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]string{"type": "string", "description": "Name of the note to delete"},
+				},
+				"required": []string{"name"},
+			},
+		},
+	})
+
+	tools = append(tools, Tool{
+		Type: "function",
+		Function: FunctionDefinition{
+			Name:        "name_session",
+			Description: "Give the current session a name. This helps organize and restore sessions later.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]string{"type": "string", "description": "New name for the session (use dashes for spaces, e.g., 'implement-auth-feature')"},
+				},
+				"required": []string{"name"},
+			},
+		},
+	})
+
+	// Add background command tools only in Build mode
+	if operationMode == Build {
+		tools = append(tools, Tool{
+			Type: "function",
+			Function: FunctionDefinition{
+				Name:        "kill_background_command",
+				Description: "Kill a running background command by PID.",
+				Parameters: map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{"pid": map[string]interface{}{"type": "integer"}},
+					"required":   []string{"pid"},
+				},
+			},
+		})
+		tools = append(tools, Tool{
+			Type: "function",
+			Function: FunctionDefinition{
+				Name:        "get_background_logs",
+				Description: "Get the logs (stdout/stderr) of a background command by PID.",
+				Parameters: map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{"pid": map[string]interface{}{"type": "integer"}},
+					"required":   []string{"pid"},
+				},
+			},
+		})
+		tools = append(tools, Tool{
+			Type: "function",
+			Function: FunctionDefinition{
+				Name:        "list_background_commands",
+				Description: "List all running background commands.",
+				Parameters:  map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+			},
+		})
+	}
+
+
+	// Add suggest_plan tool only in Plan mode
+	if operationMode == Plan {
+		tools = append(tools, Tool{
+			Type: "function",
+			Function: FunctionDefinition{
+				Name:        "suggest_plan",
+				Description: "Suggest a plan to the user and ask for approval.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"plan": map[string]string{"type": "string", "description": "The detailed plan to present to the user"},
+					},
+					"required": []string{"plan"},
+				},
+			},
+		})
+	}
 
 	// Add generic MCP tool
 	tools = append(tools, Tool{

--- a/src/types.go
+++ b/src/types.go
@@ -22,7 +22,8 @@ type Config struct {
 	ModelContextLength    int     `json:"model_context_length"`
 	Stream                bool    `json:"stream"`
 	SubagentsEnabled      bool        `json:"subagents_enabled"`
-	ExecutionMode         ExecuteMode `json:"execution_mode"`
+	ExecutionMode         ExecuteMode   `json:"execution_mode"`
+	OperationMode         OperationMode `json:"operation_mode"`
 	MCPs                  map[string]MCPServer `json:"mcp_servers"`
 }
 const (
@@ -34,6 +35,16 @@ const (
 
 // ExecuteMode is the mode for executing a command.
 type ExecuteMode string
+
+const (
+	// Build is the default operation mode, which allows command execution.
+	Build OperationMode = "build"
+	// Plan is the operation mode that blocks all command execution and focuses on planning.
+	Plan OperationMode = "plan"
+)
+
+// OperationMode is the mode of operation (Plan or Build).
+type OperationMode string
 
 // Agent represents an AI agent with its properties and message history
 type Agent struct {
@@ -146,4 +157,8 @@ type KillBackgroundCommandArgs struct {
 
 type GetBackgroundLogsArgs struct {
 	PID int `json:"pid"`
+}
+
+type SwitchOperationModeArgs struct {
+	Mode string `json:"mode"`
 }


### PR DESCRIPTION
Introduce a distinct "Plan" operation mode to separate planning from implementation. This mode blocks command execution and provides specific tools for creating and verifying plans.

- Add `OperationMode` (Plan/Build) separate from `ExecuteMode` (Ask/YOLO)
- Implement `suggest_plan` tool for interactive user approval
- Automatically switch to Build mode upon plan approval
- Restrict available tools based on current operation mode
- Update system prompts to reflect mode-specific constraints
- Add `/plan` and `/mode` commands for mode management
- Add `/ask` command to toggle execution safety confirmation