### PR TITLE
feat(cli): add sandbox mode and environment detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ USER appuser
 # Set working directory to workspace so mounted files are accessible
 WORKDIR /workspace
 
-ENTRYPOINT ["./agent-go"]
+ENTRYPOINT ["/app/agent-go"]


### PR DESCRIPTION
Introduces a new `/sandbox` command to relaunch the agent within a Docker container. Adds environment detection to display sandbox status in the CLI banner and updates the Dockerfile entrypoint.