### PR TITLE
docs: update documentation for modes and commands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,8 @@ The main application serves as the entry point and orchestrates the overall flow
 - **Custom Instructions**: Support for AGENTS.md file for custom agent behavior
 - **Command Line Task Execution**: Direct task execution without interactive mode
 - **Shell Mode**: Direct command execution interface for interactive shell sessions
+- **Plan Mode**: A strategic mode where command execution is blocked, allowing users to brainstorm and plan complex tasks safely
+- **YOLO Mode**: "You Only Look Once" mode for rapid, uninterrupted command execution without confirmation prompts
 
 ### 2. Configuration Management (`config.go`)
 
@@ -94,12 +96,15 @@ Handles secure shell command execution:
 - **Multi-step Execution**: Supports chained commands with `&&` operator
 - **Platform Independence**: Works across different operating systems (Windows, macOS, Linux)
 - **Command Display**: Shows executed commands with color coding for user feedback
+- **Ask/YOLO Modes**: Configurable execution safety with "Ask" (confirm before run) and "YOLO" (auto-run) modes
+- **Plan Mode Restriction**: Enforces safety by blocking command execution when in Plan mode
 
 ### 5. Tool Management (`tools.go` and `processor.go`)
 
 Defines and processes available tools for the AI agent:
 
 **tools.go:**
+
 - **Tool Definitions**: Defines schemas for all available tools
 - **Tool Registry**: Manages which tools are available to the agent
 - **Conditional Tools**: Some tools (like `spawn_agent`) are conditionally available
@@ -107,6 +112,7 @@ Defines and processes available tools for the AI agent:
 - **Schema Validation**: Ensures tool parameters match expected types
 
 **processor.go:**
+
 - **Tool Call Processing**: Handles execution of tool calls from API responses
 - **Error Handling**: Manages tool execution errors gracefully
 - **Result Formatting**: Formats tool output for the AI
@@ -139,6 +145,7 @@ Manages Model Context Protocol server connections and tool calls:
 - **Dynamic Tool Loading**: Tools are loaded dynamically from server schemas
 
 **MCP Server Types:**
+
 - **stdio-based**: Local servers using standard input/output (e.g., `npx -y @upstash/context7-mcp`)
 - **Command-based**: Servers launched via shell commands
 
@@ -221,6 +228,7 @@ Provides persistent knowledge storage across sessions:
 - **Note Mentions**: Support for `#note-name` syntax to inject note content
 
 ### 14. Auto-completion (`completion.go`)
+
 Provides intelligent command-line autocompletion:
 
 - **Model Completion**: Fetches available models from the API for autocompletion
@@ -280,6 +288,7 @@ Agent-Go integrates with MCP servers to extend functionality:
 - **Tool Information**: MCP tools and descriptions are injected into the system prompt
 
 **MCP Workflow:**
+
 1. Server configuration stored in config.json
 2. On startup or tool use, client connects to server
 3. Server capabilities are queried (tools, resources)
@@ -338,12 +347,14 @@ Support for `AGENTS.md` file for custom agent behavior:
 Agent-Go now supports unlimited conversation history with intelligent compression capabilities:
 
 ### Unlimited Context
+
 - **No Message Limits**: Removed the previous 20-message constraint
 - **Memory Management**: While unlimited, users should be mindful of very long conversations
 - **Token Management**: Users can use `/compress` to manage context length
 - **Auto-compression**: Automatically compresses context when approaching token limits
 
 ### Context Compression
+
 - **Intelligent Summarization**: Uses the same AI model to compress conversation history
 - **New Chat Threads**: Creates fresh chat sessions with compressed context as system message
 - **Key Information Preservation**: Maintains important details and conversation flow
@@ -351,6 +362,7 @@ Agent-Go now supports unlimited conversation history with intelligent compressio
 - **Configurable Threshold**: Users can set auto-compression thresholds
 
 ### Compression Process
+
 1. **Trigger**: User executes `/compress` command or auto-compression threshold is reached
 2. **Validation**: Checks if there are messages to compress
 3. **API Request**: Sends conversation history to AI for summarization
@@ -359,6 +371,7 @@ Agent-Go now supports unlimited conversation history with intelligent compressio
 6. **Token Reset**: Resets token counter after compression
 
 ### Auto-compression Logic
+
 - **Threshold**: Automatically compresses when token count exceeds 75% of context length
 - **Configurable**: Users can adjust the threshold via environment variables
 - **Smart Detection**: Only compresses when there are sufficient messages to summarize

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -109,6 +109,63 @@ Exited shell mode.
 - Slash commands are not available while in shell mode.
 - Commands are executed with platform-specific shell handling (cmd.exe on Windows, sh on Unix-like systems)
 
+### `/clear`
+
+Clears the current conversation context (message history) without creating a new session or compressing context.
+
+**Usage:**
+
+```
+/clear
+```
+
+**Example:**
+
+```
+> /clear
+Context cleared.
+```
+
+### `/sandbox`
+
+Relaunches Agent-Go in a Docker sandbox environment for isolated execution.
+
+**Usage:**
+
+```
+/sandbox
+```
+
+**Example:**
+
+```
+> /sandbox
+Building Docker image...
+Starting sandbox environment...
+```
+
+**Notes:**
+
+- Requires Docker to be installed and running
+- Mounts the current working directory and configuration
+- Useful for executing potentially unsafe commands in isolation
+
+### `/bg` (Background Commands)
+
+Manage background processes directly from the agent interface.
+
+- **`/bg list`**: List all running background processes
+- **`/bg view <pid>`**: View the logs (stdout/stderr) for a specific process ID
+- **`/bg kill <pid>`**: Terminate a background process
+
+**Usage:**
+
+```
+/bg list
+/bg view 12345
+/bg kill 12345
+```
+
 ### `/quit`
 
 Exits the Agent-Go application gracefully, saving any unsaved changes and cleaning up resources.
@@ -291,6 +348,7 @@ Session 'session-20251218-123456' saved successfully.
 ```
 
 **Notes:**
+
 - Automatically saves the current conversation history
 - Generates a unique session name with timestamp
 - Session data includes compressed context and metadata
@@ -320,6 +378,7 @@ Current Session: session-20251218-123456
 ```
 
 **Notes:**
+
 - Displays creation time, last access time, message count, and token usage
 - Shows the current active session
 - Sessions are ordered by last access time
@@ -336,6 +395,7 @@ Restores a previously saved session, loading its conversation history and contex
 ```
 
 **Parameters:**
+
 - `name`: The name of the session to restore
 
 **Example:**
@@ -347,6 +407,7 @@ Loaded 150 messages with 89,215 tokens.
 ```
 
 **Notes:**
+
 - Replaces current conversation with the restored session
 - Compressed context is automatically decompressed
 - All session metadata is preserved
@@ -364,6 +425,7 @@ Deletes a saved session permanently.
 ```
 
 **Parameters:**
+
 - `name`: The name of the session to delete
 
 **Example:**
@@ -374,6 +436,7 @@ Session 'old-session' deleted successfully.
 ```
 
 **Notes:**
+
 - Permanently removes the session file
 - Cannot be undone
 - Useful for cleaning up old or unused sessions
@@ -395,6 +458,7 @@ Starts the Agent Studio interface for creating custom agents. You can optionally
 ```
 
 **Parameters:**
+
 - `spec` (optional): Initial agent specification
 
 **Example:**
@@ -413,6 +477,7 @@ Enter your agent description, or type 'help' for guidance.
 ```
 
 **Agent Studio Features:**
+
 - Interactive chat interface for agent creation
 - Validates agent specifications
 - Only permits agent creation (rejects all other tools)
@@ -486,6 +551,7 @@ Displays the detailed definition of a specific agent, including its system promp
 ```
 
 **Parameters:**
+
 - `name`: The name of the agent to view
 
 **Example:**
@@ -535,6 +601,7 @@ Activates a specific agent for the current chat session. This rebuilds the syste
 ```
 
 **Parameters:**
+
 - `name`: The name of the agent to activate
 
 **Example:**
@@ -547,6 +614,7 @@ Context cleared for focused agent operation.
 ```
 
 **Notes:**
+
 - Clears current conversation context
 - Rebuilds system prompt with agent's configuration
 - Applies agent-specific model settings (if any)
@@ -573,6 +641,7 @@ Context cleared.
 ```
 
 **Notes:**
+
 - Returns to the default agent behavior
 - Restores previous model configuration
 - Clears conversation context
@@ -589,6 +658,7 @@ Deletes a saved agent definition.
 ```
 
 **Parameters:**
+
 - `name`: The name of the agent to delete
 
 **Example:**
@@ -599,6 +669,7 @@ Agent 'test-agent' deleted successfully.
 ```
 
 **Notes:**
+
 - Permanently removes the agent definition
 - Cannot delete the built-in `default` agent
 - Validates agent existence before deletion
@@ -639,6 +710,7 @@ Session Information:
 ```
 
 **Notes:**
+
 - Shows both prompt and completion token counts
 - Displays tokens used for reasoning (if applicable)
 - Provides cost estimation based on current model pricing
@@ -678,6 +750,7 @@ Session: session-20251218-123456
 ```
 
 **Notes:**
+
 - Tracks costs across sessions and time periods
 - Provides historical cost data for budgeting
 - Breaks down costs by operation type
@@ -707,6 +780,7 @@ Reduced logging output.
 ```
 
 **Notes:**
+
 - Enables detailed logging for debugging
 - Shows internal agent operations and decision-making
 - Useful for troubleshooting complex issues
@@ -739,6 +813,7 @@ Security analysis complete.
 ```
 
 **Notes:**
+
 - Creates a specialized subagent for security analysis
 - Reviews code for common vulnerabilities
 - Provides security recommendations
@@ -767,6 +842,7 @@ Prompt saved and ready for execution.
 ```
 
 **Notes:**
+
 - Opens nano text editor for complex input
 - Useful for multi-line prompts or commands
 - Automatically saves and returns to Agent-Go
@@ -778,6 +854,7 @@ Prompt saved and ready for execution.
 Agent-Go supports background command execution through specialized tools:
 
 **`execute_command` with `background` parameter:**
+
 ```
 {
   "command": "long-running-task.sh",
@@ -795,6 +872,7 @@ Lists all currently running background commands.
 Terminates a specific background command.
 
 **Notes:**
+
 - Background commands run asynchronously
 - Process IDs are tracked for management
 - Output is streamed in real-time
@@ -1022,7 +1100,7 @@ The API endpoint is https://api.example.com/v1
 
 You can also ask the AI to create, update, or delete notes through natural conversation:
 
-> Create a note called "api_endpoint" with content "The API endpoint is https://api.example.com/v1"
+> Create a note called "api_endpoint" with content "The API endpoint is <https://api.example.com/v1>"
 Created note: api_endpoint
 
 > Update the api_endpoint note to use v2
@@ -1033,8 +1111,9 @@ Deleted note: old_database_config
 
 > Show me all my notes
 Notes:
-  - api_endpoint (updated: 2025-11-25 08:30)
-  - database_schema (updated: 2025-11-25 09:15)
+
+- api_endpoint (updated: 2025-11-25 08:30)
+- database_schema (updated: 2025-11-25 09:15)
 
 ## Advanced Usage
 
@@ -1221,6 +1300,55 @@ export DEBUG=1
 This will provide detailed logging information to help diagnose issues.
 
 ## Additional Features
+
+### `/mode` (or `/plan`)
+
+Toggles between **Plan** mode and **Build** mode.
+
+- **Build Mode** (Default): The agent has access to all tools, including `execute_command`. This is the standard mode for getting things done.
+- **Plan Mode**: The agent is restricted from executing commands. It can only think and use the `suggest_plan` tool to propose a detailed plan to the user. This is useful for complex tasks where you want to agree on a strategy before any code is modified.
+
+**Usage:**
+
+```
+/mode
+# or
+/plan
+```
+
+**Example:**
+
+```
+> /mode
+Switched to Plan mode.
+
+> /plan
+Switched to Build mode.
+```
+
+### `/ask on|off`
+
+Toggles between **Ask** mode and **YOLO** mode for command execution.
+
+- **Ask Mode** (Default): The agent will ask for your confirmation before executing potentially dangerous tools (like `execute_command`).
+- **YOLO Mode**: "You Only Look Once" - The agent will execute commands immediately without asking for confirmation. Use with caution!
+
+**Usage:**
+
+```
+/ask on
+/ask off
+```
+
+**Example:**
+
+```
+> /ask off
+Switched to YOLO mode.
+
+> /ask on
+Switched to Ask mode.
+```
 
 ### Streaming Mode
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,8 @@ The configuration file is automatically created on first run or when settings ar
 |-----------|------|---------|-------------|
 | `stream` | bool | `false` | Enable/disable streaming mode for real-time responses |
 | `subagents_enabled` | bool | `true` | Enable/disable sub-agent spawning capability |
+| `execution_mode` | string | `"ask"` | Execution mode: `"ask"` (confirm commands) or `"yolo"` (auto-execute) |
+| `operation_mode` | string | `"build"` | Operation mode: `"build"` (execute commands) or `"plan"` (plan only) |
 
 #### MCP Server Configuration
 
@@ -124,6 +126,8 @@ Environment variables provide a way to override configuration settings without m
 | `MODEL_CONTEXT_LENGTH` | Model context length | `131072` |
 | `STREAM_ENABLED` | Enable streaming mode (`1`=enabled, `0`=disabled) | `1` or `true` |
 | `SUBAGENTS_ENABLED` | Enable sub-agent spawning (`1`=enabled, `0`=disabled) | `1` or `true` |
+| `EXECUTION_MODE` | Set execution mode | `"ask"` or `"yolo"` |
+| `OPERATION_MODE` | Set operation mode | `"build"` or `"plan"` |
 
 ### Environment Variable Examples
 

--- a/src/executor.go
+++ b/src/executor.go
@@ -67,7 +67,7 @@ func confirmAndExecute(config *Config, command string) (string, error) {
 func executeCommand(command string) (string, error) {
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
-		cmd = exec.Command("pwsh", "-CommandWithArgs", command)
+		cmd = exec.Command("cmd", "/C", command)
 	} else {
 		cmd = exec.Command("sh", "-c", command)
 	}
@@ -86,7 +86,7 @@ func executeCommand(command string) (string, error) {
 func executeBackgroundCommand(command string) (string, error) {
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
-		cmd = exec.Command("pwsh", "-CommandWithArgs", command)
+		cmd = exec.Command("cmd", "/C", command)
 	} else {
 		cmd = exec.Command("sh", "-c", command)
 	}
@@ -212,7 +212,12 @@ func executeSkill(command string, argsJSON []byte) (string, error) {
 	}
 
 	// Fallback to shell execution while safely passing SKILL_ARGS via the environment.
-	cmd := exec.Command("sh", "-c", command)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/C", command)
+	} else {
+		cmd = exec.Command("sh", "-c", command)
+	}
 	cmd.Env = append(os.Environ(), fmt.Sprintf("SKILL_ARGS=%s", string(argsJSON)))
 
 	var outBuf bytes.Buffer


### PR DESCRIPTION
- Update architecture documentation to include Plan, YOLO, and Shell modes
- Add command reference for /clear, /sandbox, /bg, /mode, and /ask
- Document execution_mode and operation_mode configuration
- fix(executor): switch to cmd.exe for Windows command execution