### PR TITLE
fix(windows): improve compatibility for installer and edit command

### DIFF
--- a/install-agent-go.sh
+++ b/install-agent-go.sh
@@ -78,7 +78,17 @@ if [ "$ROLLING" = true ]; then
 
     echo "Installing agent-go (rolling)..."
     chmod +x "agent-go${EXT}"
-    sudo mv "./agent-go${EXT}" "/usr/local/bin/agent-go${EXT}"
+    if [ "$OS" == "windows" ]; then
+        # On Windows (Git Bash/MinGW), sudo might not be available or needed
+        # Try to install to a common location or just advise user
+        INSTALL_DIR="$HOME/bin"
+        mkdir -p "$INSTALL_DIR"
+        mv "./agent-go${EXT}" "$INSTALL_DIR/agent-go${EXT}"
+        echo "Installed to $INSTALL_DIR"
+        echo "Please ensure $INSTALL_DIR is in your PATH."
+    else
+        sudo mv "./agent-go${EXT}" "/usr/local/bin/agent-go${EXT}"
+    fi
 
 else
     echo "Fetching latest version..."
@@ -97,7 +107,15 @@ else
 
     echo "Installing agent-go..."
     chmod +x "agent-go${EXT}"
-    sudo mv "./agent-go${EXT}" "/usr/local/bin/agent-go${EXT}"
+    if [ "$OS" == "windows" ]; then
+        INSTALL_DIR="$HOME/bin"
+        mkdir -p "$INSTALL_DIR"
+        mv "./agent-go${EXT}" "$INSTALL_DIR/agent-go${EXT}"
+        echo "Installed to $INSTALL_DIR"
+        echo "Please ensure $INSTALL_DIR is in your PATH."
+    else
+        sudo mv "./agent-go${EXT}" "/usr/local/bin/agent-go${EXT}"
+    fi
 fi
 
 # Verify installation

--- a/src/system.go
+++ b/src/system.go
@@ -23,6 +23,9 @@ func getSystemInfo() string {
 }
 
 func getDistro() string {
+	if runtime.GOOS == "windows" {
+		return "Windows"
+	}
 	if runtime.GOOS != "linux" {
 		return "N/A"
 	}


### PR DESCRIPTION
- Replace hardcoded /tmp with os.TempDir() and default to notepad for /edit command on Windows
- Update getDistro to correctly identify Windows OS
- Modify installer to support non-root installation in Git Bash/MinGW environments